### PR TITLE
Show canonical link

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
 <meta name="theme-color" content="DeepSkyBlue">
 
 <!-- Allure. -->
+<link rel="canonical" href="https://ryanve.github.io/talkative/">
 <meta name="description" content="UX writer, content strategist, web creative, blogger, editor">
 <link rel="shortcut icon" href="https://user-images.githubusercontent.com/949985/54581426-f76ed200-49c9-11e9-83ab-581b10243515.png">
 <meta property="og:image" content="https://user-images.githubusercontent.com/949985/54581426-f76ed200-49c9-11e9-83ab-581b10243515.png">


### PR DESCRIPTION
So that the portable version has the link in the source and for SEO